### PR TITLE
Change StackFrame: sometimes line numbers are negative

### DIFF
--- a/src/Test/WebDriver/Exceptions/Internal.hs
+++ b/src/Test/WebDriver/Exceptions/Internal.hs
@@ -143,7 +143,7 @@ failedCommand t m = throwIO . FailedCommand t =<< mkFailedCommandInfo m
 data StackFrame = StackFrame { sfFileName   :: String
                              , sfClassName  :: String
                              , sfMethodName :: String
-                             , sfLineNumber :: Word
+                             , sfLineNumber :: Int
                              }
                 deriving (Eq)
 


### PR DESCRIPTION
This became a problem when Aeson started strictly checking numbers for
bounds errors.